### PR TITLE
Fix `tl_content.tl_mae_img_map_id` SQL definition

### DIFF
--- a/dca/tl_content.php
+++ b/dca/tl_content.php
@@ -6,6 +6,6 @@ $GLOBALS['TL_DCA']['tl_content']['fields']['tl_mae_img_map_id'] = array(
     'inputType'               => 'select',
     'foreignKey'              => 'tl_mae_img_map.title',
     'eval'       => array('mandatory'=>true, 'tl_class'=>'w50','chosen'=>true),
-    'sql'        => "int(10) unsigned NOT NULL"
+    'sql'        => "int(10) unsigned NOT NULL default 0"
 );
 $GLOBALS['TL_DCA']['tl_content']['palettes']['mae_img_map'] = '{type_legend},type,headline;{source_legend},singleSRC,tl_mae_img_map_id;{image_legend},alt,title,size,imagemargin;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space;{invisible_legend:hide},invisible,start,stop';


### PR DESCRIPTION
`tl_content.tl_mae_img_map_id`'s SQL definition currently has no default set, which will lead to the following error:

```
An exception occurred while executing 'INSERT INTO tl_content (`pid`, `sorting`, `ptable`, `tstamp`) VALUES (154, 384, 'tl_article', 0)': SQLSTATE[HY000]: General error: 1364 Field 'tl_mae_img_map_id' doesn't have a default value
```

This PR adds the appropriate default.